### PR TITLE
fix: user ranking entity

### DIFF
--- a/src/main/java/org/secretjuju/kono/config/SecurityConfig.java
+++ b/src/main/java/org/secretjuju/kono/config/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig {
 						.successHandler(successHandler())
 						.authorizationEndpoint(authorization -> authorization
 								.authorizationRequestResolver(customAuthorizationRequestResolver()))
-						.defaultSuccessUrl("http://localhost:5173/", true));
+						.defaultSuccessUrl("http://dev.playkono.com", true));
 
 		return http.build();
 	}

--- a/src/main/java/org/secretjuju/kono/config/SecurityConfig.java
+++ b/src/main/java/org/secretjuju/kono/config/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
 		http.csrf(AbstractHttpConfigurer::disable)
 				.authorizeHttpRequests(auth -> auth
 						.requestMatchers("/", "/login", "/logout", "/error", "/css/**", "/js/**", "/oauth2/**")
-						.permitAll().requestMatchers("/api/**").authenticated().anyRequest().permitAll())
+						.permitAll().requestMatchers("/api/" + "**").authenticated().anyRequest().permitAll())
 				.exceptionHandling(exceptionHandling -> exceptionHandling
 						.defaultAuthenticationEntryPointFor(new CustomAuthenticationEntryPoint(objectMapper),
 								new AntPathRequestMatcher("/api/**"))
@@ -57,7 +57,7 @@ public class SecurityConfig {
 						.successHandler(successHandler())
 						.authorizationEndpoint(authorization -> authorization
 								.authorizationRequestResolver(customAuthorizationRequestResolver()))
-						.defaultSuccessUrl("http://api.playkono.com/", true));
+						.defaultSuccessUrl("http://localhost:5173/", true));
 
 		return http.build();
 	}

--- a/src/main/java/org/secretjuju/kono/entity/DailyRanking.java
+++ b/src/main/java/org/secretjuju/kono/entity/DailyRanking.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -27,8 +26,8 @@ public class DailyRanking {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Integer id;
 
-	@OneToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "user_id", nullable = false, unique = true)
+	@OneToOne
+	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 
 	@Column(name = "current_total_assets", nullable = false, columnDefinition = "BIGINT UNSIGNED")

--- a/src/main/java/org/secretjuju/kono/entity/DailyRanking.java
+++ b/src/main/java/org/secretjuju/kono/entity/DailyRanking.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -26,8 +27,8 @@ public class DailyRanking {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Integer id;
 
-	@OneToOne
-	@JoinColumn(name = "user_id", nullable = false)
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false, unique = true)
 	private User user;
 
 	@Column(name = "current_total_assets", nullable = false, columnDefinition = "BIGINT UNSIGNED")

--- a/src/main/java/org/secretjuju/kono/entity/TotalRanking.java
+++ b/src/main/java/org/secretjuju/kono/entity/TotalRanking.java
@@ -5,7 +5,6 @@ import java.time.LocalDateTime;
 import jakarta.persistence.*;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -31,8 +30,8 @@ public class TotalRanking {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Integer id;
 
-	@OneToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "user_id", nullable = false, unique = true)
+	@OneToOne
+	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 
 	@Column(name = "current_total_assets", nullable = false, columnDefinition = "BIGINT UNSIGNED")

--- a/src/main/java/org/secretjuju/kono/entity/TotalRanking.java
+++ b/src/main/java/org/secretjuju/kono/entity/TotalRanking.java
@@ -30,8 +30,8 @@ public class TotalRanking {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Integer id;
 
-	@OneToOne
-	@JoinColumn(name = "user_id", nullable = false)
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false, unique = true)
 	private User user;
 
 	@Column(name = "current_total_assets", nullable = false, columnDefinition = "BIGINT UNSIGNED")

--- a/src/main/java/org/secretjuju/kono/entity/User.java
+++ b/src/main/java/org/secretjuju/kono/entity/User.java
@@ -7,7 +7,6 @@ import java.util.List;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -72,7 +71,7 @@ public class User {
 	@OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
 	private DailyRanking dailyRanking;
 
-	@OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+	@OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
 	private TotalRanking totalRanking;
 
 	@PrePersist


### PR DESCRIPTION
## 📌 Description
유저 회원탈퇴를 위한 엔티티 연관관계 재설정(유저테이블의  랭킹 필드의 연관관계 주체가 될 수있게 수정)

## 🔗 Related Issues
#53 
## ✨ Changes Made
User가 관계의 주인이 되어 DailyRanking과 TotalRanking을 직접 관리할 수 있게 설정

1. ✅ [테스트 1]: 회원 탈퇴 테스트 (회원 탈퇴 시 유저와 연관된 데이터베이스 삭제 되는것 확인)


## ✅ Checklist
<!-- PR 작성 시 다음 항목들을 확인하세요. -->

- [x] 🔄 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] ✅ 모든 테스트가 성공적으로 통과했습니다.
- [ ] 📚 관련 문서를 업데이트했습니다.
- [x] 🔗 PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 🎨 코드 스타일 가이드라인을 준수했습니다.
- [x] 👀 코드 리뷰어를 지정했습니다.

## 💡 Additional Notes
<!-- 리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요. -->
