### PR TITLE
fix: 코인 매도시 로직 수정 변경,전체 투자금 수익률 로직 변경

### DIFF
--- a/src/main/java/org/secretjuju/kono/config/SecurityConfig.java
+++ b/src/main/java/org/secretjuju/kono/config/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig {
 						.successHandler(successHandler())
 						.authorizationEndpoint(authorization -> authorization
 								.authorizationRequestResolver(customAuthorizationRequestResolver()))
-						.defaultSuccessUrl("http://dev.playkono.com", true));
+						.defaultSuccessUrl("http://localhost:5173", true));
 		return http.build();
 	}
 
@@ -76,7 +76,7 @@ public class SecurityConfig {
 	@Bean
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();
-		configuration.setAllowedOrigins(Arrays.asList("http://dev.playkono.com")); // 프론트엔드 주소
+		configuration.setAllowedOrigins(Arrays.asList("http://dev.playkono.com", "http://localhost:4173")); // 프론트엔드 주소
 		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
 		configuration.setAllowedHeaders(Arrays.asList("*"));
 		configuration.setAllowCredentials(true);

--- a/src/main/java/org/secretjuju/kono/repository/CashBalanceRepository.java
+++ b/src/main/java/org/secretjuju/kono/repository/CashBalanceRepository.java
@@ -5,7 +5,16 @@ import java.util.Optional;
 import org.secretjuju.kono.entity.CashBalance;
 import org.secretjuju.kono.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
-public interface CashBalanceRepository extends JpaRepository<CashBalance, Integer> {
-	Optional<CashBalance> findByUser(User user);
+import jakarta.persistence.LockModeType;
+
+@Repository
+public interface CashBalanceRepository extends JpaRepository<CashBalance, Long> {
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT cb FROM CashBalance cb WHERE cb.user = :user")
+	Optional<CashBalance> findByUserWithLock(@Param("user") User user);
 }

--- a/src/main/java/org/secretjuju/kono/repository/CoinHoldingRepository.java
+++ b/src/main/java/org/secretjuju/kono/repository/CoinHoldingRepository.java
@@ -1,11 +1,24 @@
 package org.secretjuju.kono.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.secretjuju.kono.entity.CoinHolding;
+import org.secretjuju.kono.entity.CoinInfo;
 import org.secretjuju.kono.entity.User;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
-public interface CoinHoldingRepository extends CrudRepository<CoinHolding, Long> {
+import jakarta.persistence.LockModeType;
+
+@Repository
+public interface CoinHoldingRepository extends JpaRepository<CoinHolding, Long> {
 	List<CoinHolding> findByUser(User user);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT ch FROM CoinHolding ch WHERE ch.user = :user AND ch.coinInfo = :coinInfo")
+	Optional<CoinHolding> findByUserAndCoinInfoWithLock(@Param("user") User user, @Param("coinInfo") CoinInfo coinInfo);
 }

--- a/src/main/java/org/secretjuju/kono/service/CoinService.java
+++ b/src/main/java/org/secretjuju/kono/service/CoinService.java
@@ -17,21 +17,32 @@ import org.secretjuju.kono.entity.CoinInfo;
 import org.secretjuju.kono.entity.CoinTransaction;
 import org.secretjuju.kono.entity.User;
 import org.secretjuju.kono.exception.CustomException;
+import org.secretjuju.kono.repository.CashBalanceRepository;
+import org.secretjuju.kono.repository.CoinHoldingRepository;
 import org.secretjuju.kono.repository.CoinRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Service
+@Slf4j
 public class CoinService {
 
 	private final CoinRepository coinRepository;
 	private final UserService userService;
 	private final UpbitService upbitService;
+	private final CashBalanceRepository cashBalanceRepository;
+	private final CoinHoldingRepository coinHoldingRepository;
 
-	public CoinService(CoinRepository coinRepository, UserService userService, UpbitService upbitService) {
+	public CoinService(CoinRepository coinRepository, UserService userService, UpbitService upbitService,
+			CashBalanceRepository cashBalanceRepository, CoinHoldingRepository coinHoldingRepository) {
 		this.coinRepository = coinRepository;
 		this.userService = userService;
 		this.upbitService = upbitService;
+		this.cashBalanceRepository = cashBalanceRepository;
+		this.coinHoldingRepository = coinHoldingRepository;
 	}
 
 	public List<CoinInfoResponseDto> getAllCoinInfo() {
@@ -53,7 +64,7 @@ public class CoinService {
 		return tickerResponse.getTrade_price();
 	}
 
-	@Transactional
+	@Transactional(isolation = Isolation.REPEATABLE_READ)
 	public void createCoinOrder(CoinSellBuyRequestDto coinSellBuyRequestDto) {
 		// 현재 로그인한 사용자 정보를 가져옵니다.
 		User currentUser = userService.getCurrentUser();
@@ -161,12 +172,15 @@ public class CoinService {
 	}
 
 	private void processBuy(User user, CoinInfo coinInfo, CoinSellBuyRequestDto request) {
-		// 현금 잔액 확인
-		CashBalance cashBalance = user.getCashBalance();
-		if (cashBalance == null) {
-			cashBalance = new CashBalance();
-			user.setCashBalance(cashBalance);
-		}
+		// 현금 잔액 락 획득
+		CashBalance cashBalance = cashBalanceRepository.findByUserWithLock(user).orElseGet(() -> {
+			CashBalance newBalance = new CashBalance();
+			user.setCashBalance(newBalance);
+			return newBalance;
+		});
+
+		// 코인 보유 정보 락 획득
+		Optional<CoinHolding> existingHolding = coinHoldingRepository.findByUserAndCoinInfoWithLock(user, coinInfo);
 
 		// 현금 잔액이 충분한지 확인
 		if (cashBalance.getBalance() < request.getOrderAmount()) {
@@ -177,9 +191,6 @@ public class CoinService {
 		cashBalance.setBalance(cashBalance.getBalance() - request.getOrderAmount());
 
 		// 코인 보유량 업데이트
-		Optional<CoinHolding> existingHolding = user.getCoinHoldings().stream()
-				.filter(holding -> holding.getCoinInfo().getId().equals(coinInfo.getId())).findFirst();
-
 		if (existingHolding.isPresent()) {
 			// 기존 보유량이 있는 경우 수량과 평균 매수가 업데이트
 			CoinHolding holding = existingHolding.get();
@@ -188,29 +199,26 @@ public class CoinService {
 
 			holding.setHoldingQuantity(newTotalQuantity);
 			holding.setHoldingPrice(holding.getHoldingPrice() + newHoldingPrice); // 항상 코인당 평균 매수가로 저장
-			// // 기존 보유량이 있는 경우 수량 증가
-			// CoinHolding holding = existingHolding.get();
-			// holding.setHoldingQuantity(holding.getHoldingQuantity() +
-			// request.getOrderQuantity());
-			// holding.setHoldingPrice((holding.getHoldingPrice() + (request.getOrderPrice()
-			// * request.getOrderQuantity()))
-			// / (holding.getHoldingQuantity() + request.getOrderQuantity()));
 		} else {
 			// 기존 보유량이 없는 경우 새로 생성
 			CoinHolding newHolding = new CoinHolding();
 			newHolding.setCoinInfo(coinInfo);
 			newHolding.setHoldingQuantity(request.getOrderQuantity());
-			// newHolding.setHoldingPrice(request.getOrderPrice() *
-			// request.getOrderQuantity());
 			newHolding.setHoldingPrice(request.getOrderPrice() * request.getOrderQuantity());
 			user.addCoinHolding(newHolding);
 		}
 	}
 
 	private void processSell(User user, CoinInfo coinInfo, CoinSellBuyRequestDto request) {
-		// 해당 코인 보유량 확인
-		Optional<CoinHolding> existingHolding = user.getCoinHoldings().stream()
-				.filter(holding -> holding.getCoinInfo().getId().equals(coinInfo.getId())).findFirst();
+		// 코인 보유 정보 락 획득
+		Optional<CoinHolding> existingHolding = coinHoldingRepository.findByUserAndCoinInfoWithLock(user, coinInfo);
+
+		// 현금 잔액 락 획득
+		CashBalance cashBalance = cashBalanceRepository.findByUserWithLock(user).orElseGet(() -> {
+			CashBalance newBalance = new CashBalance();
+			user.setCashBalance(newBalance);
+			return newBalance;
+		});
 
 		if (existingHolding.isEmpty() || existingHolding.get().getHoldingQuantity() < request.getOrderQuantity()) {
 			throw new CustomException(403, "코인 보유량이 부족합니다.");
@@ -221,7 +229,6 @@ public class CoinService {
 			// 코인 보유량 감소
 			System.out.println("유효한 거래입니다!");
 			CoinHolding holding = existingHolding.get();
-			holding.setHoldingQuantity(holding.getHoldingQuantity() - request.getOrderQuantity());
 
 			System.out.println(holding.getHoldingPrice()
 					- ((holding.getHoldingPrice() / holding.getHoldingQuantity()) * request.getOrderQuantity())); ///// 로그확인
@@ -230,16 +237,13 @@ public class CoinService {
 			holding.setHoldingPrice(holding.getHoldingPrice()
 					- ((holding.getHoldingPrice() / holding.getHoldingQuantity()) * request.getOrderQuantity()));
 
-			// 코인을 모두 판매한 경우 보유 목록에서 제거
-			if (holding.getHoldingQuantity() <= 0) {
+			holding.setHoldingQuantity(holding.getHoldingQuantity() - request.getOrderQuantity());
+
+			// 코인을 모두 판매한 경우 보유 목록에서 제거(0.1오류 로직 부분 검토 코드)
+			if (holding.getHoldingQuantity() <= 0.00001) {
 				user.getCoinHoldings().remove(holding);
 			}
 			// 현금 잔액 증가
-			CashBalance cashBalance = user.getCashBalance();
-			if (cashBalance == null) {
-				cashBalance = new CashBalance();
-				user.setCashBalance(cashBalance);
-			}
 			cashBalance.setBalance(cashBalance.getBalance() + request.getOrderAmount());
 		}
 

--- a/src/main/java/org/secretjuju/kono/service/CoinService.java
+++ b/src/main/java/org/secretjuju/kono/service/CoinService.java
@@ -240,7 +240,7 @@ public class CoinService {
 			holding.setHoldingQuantity(holding.getHoldingQuantity() - request.getOrderQuantity());
 
 			// 코인을 모두 판매한 경우 보유 목록에서 제거(0.1오류 로직 부분 검토 코드)
-			if (holding.getHoldingQuantity() <= 0.00001) {
+			if (holding.getHoldingQuantity() <= 0) {
 				user.getCoinHoldings().remove(holding);
 			}
 			// 현금 잔액 증가

--- a/src/main/java/org/secretjuju/kono/service/CoinService.java
+++ b/src/main/java/org/secretjuju/kono/service/CoinService.java
@@ -1,5 +1,6 @@
 package org.secretjuju.kono.service;
 
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -77,8 +78,7 @@ public class CoinService {
 				Long calculatedAmount = Math.round(coinSellBuyRequestDto.getOrderQuantity() * currentPrice);
 				coinSellBuyRequestDto.setOrderAmount(calculatedAmount);
 			} else {
-
-				coinSellBuyRequestDto.setOrderAmount(100000L);
+				throw new CustomException(400, "거래시 주문금액 혹은 갯수 필수값이 누락되었습니다.");
 			}
 		}
 
@@ -99,7 +99,7 @@ public class CoinService {
 		transaction.setOrderQuantity(coinSellBuyRequestDto.getOrderQuantity());
 		transaction.setOrderPrice(coinSellBuyRequestDto.getOrderPrice());
 		transaction.setOrderAmount(coinSellBuyRequestDto.getOrderAmount());
-		transaction.setCreatedAt(ZonedDateTime.now());
+		transaction.setCreatedAt(ZonedDateTime.now(ZoneId.of("Asia/Seoul"))); // 거래 시간
 		currentUser.addTransaction(transaction);
 
 		// 거래 타입에 따라 코인 보유량과 현금 잔액을 업데이트합니다.
@@ -217,27 +217,32 @@ public class CoinService {
 		} else if (request.getOrderAmount() < 5000) {
 			throw new CustomException(400, "최소 주문 금액은 5000원입니다. 현재 주문 금액: " + request.getOrderAmount());
 		}
+		if (request.getOrderQuantity() / existingHolding.get().getHoldingQuantity() <= 1) {
+			// 코인 보유량 감소
+			System.out.println("유효한 거래입니다!");
+			CoinHolding holding = existingHolding.get();
+			holding.setHoldingQuantity(holding.getHoldingQuantity() - request.getOrderQuantity());
 
-		// 코인 보유량 감소
-		CoinHolding holding = existingHolding.get();
-		holding.setHoldingQuantity(holding.getHoldingQuantity() - request.getOrderQuantity());
+			System.out.println(holding.getHoldingPrice()
+					- ((holding.getHoldingPrice() / holding.getHoldingQuantity()) * request.getOrderQuantity())); ///// 로그확인
 
-		// 매수 평균가 감소
-		holding.setHoldingPrice(holding.getHoldingPrice()
-				- (holding.getHoldingPrice() / (holding.getHoldingQuantity() * request.getOrderQuantity())));
+			// 매수 평균가 감소
+			holding.setHoldingPrice(holding.getHoldingPrice()
+					- ((holding.getHoldingPrice() / holding.getHoldingQuantity()) * request.getOrderQuantity()));
 
-		// 코인을 모두 판매한 경우 보유 목록에서 제거
-		if (holding.getHoldingQuantity() <= 0) {
-			user.getCoinHoldings().remove(holding);
+			// 코인을 모두 판매한 경우 보유 목록에서 제거
+			if (holding.getHoldingQuantity() <= 0) {
+				user.getCoinHoldings().remove(holding);
+			}
+			// 현금 잔액 증가
+			CashBalance cashBalance = user.getCashBalance();
+			if (cashBalance == null) {
+				cashBalance = new CashBalance();
+				user.setCashBalance(cashBalance);
+			}
+			cashBalance.setBalance(cashBalance.getBalance() + request.getOrderAmount());
 		}
 
-		// 현금 잔액 증가
-		CashBalance cashBalance = user.getCashBalance();
-		if (cashBalance == null) {
-			cashBalance = new CashBalance();
-			user.setCashBalance(cashBalance);
-		}
-		cashBalance.setBalance(cashBalance.getBalance() + request.getOrderAmount());
 	}
 
 	private CoinInfoResponseDto convertToCoinInfosResponse(CoinInfo coinInfo) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,6 +38,7 @@ spring:
       allowed-origins:
         - https://dev.playkono.com
         - http://localhost:5173  # 개발 환경용
+        - http://localhost:4173
       allowed-methods:
         - GET
         - POST
@@ -62,6 +63,7 @@ cloud:
       allowed-origins:
         - https://dev.playkono.com
         - http://localhost:5173
+        - http://localhost:4173
 
 thymeleaf:
   enabled: true


### PR DESCRIPTION
## 📌 Description
- 코인 매도시 로직 수정 변경,전체 투자금 수익률 로직 변경

## 🔗 Related Issues
<!-- 관련된 이슈 번호를 참고하세요. 예: Fixes #123, Closes #456 -->
#64 

## ✨ Changes Made
코인 매도 시 코인의 개수 계산과 코인의 가격 계산 순서가 잘못되어 로직 수정 및 동시성 제어를 위한 lock 설정
전체 투자금 수익 로직 변경

## 🧪 Testing
회원 가입후 비트코인 50% 구매-> 50%판매 반복 시도 후 투자금 및 코인 수익률 검토 


## ✅ Checklist
<!-- PR 작성 시 다음 항목들을 확인하세요. -->

- [x] 🔄 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] ✅ 모든 테스트가 성공적으로 통과했습니다.
- [ ] 📚 관련 문서를 업데이트했습니다.
- [ ] 🔗 PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 🎨 코드 스타일 가이드라인을 준수했습니다.
- [x] 👀 코드 리뷰어를 지정했습니다.

## 💡 Additional Notes
코인 서비스에서 코인 매도 로직 순서가 잘못되어있어 변경 및 전체 투자금(코인투자금+현금) 수익률 로직 변경  
